### PR TITLE
Suggest paramref and typeparamref in VB

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -104,7 +104,35 @@ Class C
 End Class
 "
 
-            Await VerifyItemsExistAsync(text, "code", "list", "para", "paramref", "typeparamref")
+            Await VerifyItemsExistAsync(text, "code", "list", "para")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestRepeatableNestedParamRefAndTypeParamRefTagsOnMethod() As Task
+            Dim text = "
+Class C
+    ''' <summary>
+    ''' <$$
+    ''' </summary>
+    Sub Foo(Of T)(i as Integer)
+    End Sub
+End Class
+"
+
+            Await VerifyItemsExistAsync(text, "paramref name=""i""", "typeparamref name=""T""")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestRepeatableNestedTypeParamRefTagOnClass() As Task
+            Dim text = "
+''' <summary>
+''' <$$
+''' </summary>
+Class C(Of T)
+End Class
+"
+
+            Await VerifyItemsExistAsync(text, "typeparamref name=""T""")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
@@ -376,7 +404,7 @@ Module Program
 End Module
 "
 
-            Await VerifyItemsExistAsync(text, "code", "list", "para", "paramref", "typeparamref")
+            Await VerifyItemsExistAsync(text, "code", "list", "para")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
@@ -73,20 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 // The user is typing inside an XmlElement
                 if (token.Parent.Parent.Kind() == SyntaxKind.XmlElement)
                 {
-                    // Add corresponding tags except ParamRefTag and TypeParamRefTag
-                    items.AddRange(NestedTagNames.Where(name => name != ParamRefTagName && name != TypeParamRefTagName)
-                                                 .Select(name => GetItem(name, span)));
-
-                    if (declaredSymbol != null)
-                    {
-                        // Add a ParamRefTag for each available parameter
-                        var parameters = declaredSymbol.GetParameters();
-                        items.AddRange(parameters.Select(p => CreateCompletionItem(span, FormatParameter(ParamRefTagName, p.Name))));
-
-                        // Add a TypeParamRefTag for each available type parameter
-                        var typeParameters = declaredSymbol.GetTypeParameters();
-                        items.AddRange(typeParameters.Select(t => CreateCompletionItem(span, FormatParameter(TypeParamRefTagName, t.Name))));
-                    }
+                    items.AddRange(GetNestedTags(span, declaredSymbol));
                 }
 
                 if (token.Parent.Parent.Kind() == SyntaxKind.XmlElement && ((XmlElementSyntax)token.Parent.Parent).StartTag.Name.LocalName.ValueText == ListTagName)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using System.Collections.Immutable;
@@ -117,12 +118,46 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         protected IEnumerable<string> NestedTagNames
         {
-            get { return new[] { CTagName, CodeTagName, ParaTagName, ListTagName, ParamRefTagName, TypeParamRefTagName }; }
+            get { return new[] { CTagName, CodeTagName, ParaTagName, ListTagName }; }
         }
 
-        protected IEnumerable<CompletionItem> GetNestedTags(TextSpan itemSpan)
+        protected IEnumerable<CompletionItem> GetNestedTags(TextSpan itemSpan, ISymbol declaredSymbol)
         {
-            return NestedTagNames.Select(t => GetItem(t, itemSpan));
+            return NestedTagNames.Select(t => GetItem(t, itemSpan))
+                                 .Concat(GetParamRefItems(itemSpan, declaredSymbol))
+                                 .Concat(GetTypeParamRefItems(itemSpan, declaredSymbol));
+        }
+
+        private IEnumerable<CompletionItem> GetParamRefItems(TextSpan itemSpan, ISymbol declaredSymbol)
+        {
+            var parameters = declaredSymbol?.GetParameters().Select(p => p.Name).ToSet();
+
+            if (parameters == null)
+            {
+                return SpecializedCollections.EmptyEnumerable<CompletionItem>();
+            }
+
+            return parameters.Select(p => CreateCompletionItem(
+                span: itemSpan,
+                displayText: FormatParameter(ParamRefTagName, p),
+                beforeCaretText: FormatParameterRefTag(ParamRefTagName, p),
+                afterCaretText: string.Empty));
+        }
+
+        private IEnumerable<CompletionItem> GetTypeParamRefItems(TextSpan itemSpan, ISymbol declaredSymbol)
+        {
+            var typeParameters = declaredSymbol?.GetTypeParameters().Select(t => t.Name).ToSet();
+
+            if (typeParameters == null)
+            {
+                return SpecializedCollections.EmptyEnumerable<CompletionItem>();
+            }
+
+            return typeParameters.Select(t => CreateCompletionItem(
+                span: itemSpan,
+                displayText: FormatParameter(TypeParamRefTagName, t),
+                beforeCaretText: FormatParameterRefTag(TypeParamRefTagName, t),
+                afterCaretText: string.Empty));
         }
 
         protected IEnumerable<CompletionItem> GetTopLevelRepeatableItems(TextSpan itemSpan)
@@ -146,6 +181,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected string FormatParameter(string kind, string name)
         {
             return $"{kind} {NameAttributeName}=\"{name}\"";
+        }
+
+        private string FormatParameterRefTag(string kind, string name)
+        {
+            return $"<{kind} {NameAttributeName}=\"{name}\"/>";
         }
 
         public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitChar = default(char?), CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -94,8 +94,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
             Dim grandParent = parentElement.Parent
 
+            Dim symbol = semanticModel.GetDeclaredSymbol(declaration, cancellationToken)
+
             If grandParent.IsKind(SyntaxKind.XmlElement) Then
-                items.AddRange(GetNestedTags(span))
+                items.AddRange(GetNestedTags(span, symbol))
 
                 If GetStartTagName(grandParent) = ListTagName Then
                     items.AddRange(GetListItems(span))
@@ -105,7 +107,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                     items.AddRange(GetListHeaderItems(span))
                 End If
             ElseIf token.Parent.IsKind(SyntaxKind.XmlText) AndAlso token.Parent.Parent.IsKind(SyntaxKind.XmlElement) Then
-                items.AddRange(GetNestedTags(span))
+                items.AddRange(GetNestedTags(span, symbol))
 
                 If GetStartTagName(token.Parent.Parent) = ListTagName Then
                     items.AddRange(GetListItems(span))


### PR DESCRIPTION
Moved the [type] parameter logic into the base class, and updated the VB completion provider to supply the declared symbol.

I also tweaked how the formatting is done, to ensure the inserted XML tag is automatically closed, regardless of how the list is triggered (`<` or CTRL+SPACE or CTRL+J) or how the item is committed (`>` or TAB).